### PR TITLE
Add code to have authopenid handle /login

### DIFF
--- a/authopenid/authopenid.py
+++ b/authopenid/authopenid.py
@@ -117,7 +117,7 @@ class AuthOpenIdPlugin(Component):
             on each authenticated access.
             """)
 
-    default_openid = Option('openid', 'take_default_login', False,
+    take_default_login = Option('openid', 'take_default_login', False,
             """Set to true if /login should be handled by openid.""")
 
     default_openid = Option('openid', 'default_openid', None,


### PR DESCRIPTION
This code makes it possible to have authopenid take /login.
This is useful because all trac's "not authorized" messages are hardcoded to point to /login, and if openid is the only allowed provider, this leaves users with a 404.
