### PR TITLE
Lookup username by OpenID identifier - issue 14

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,21 @@ Bug Fixes
 
 __ https://github.com/dairiki/authopenid-plugin/pull/16
 
+- On login, first try to look up the username by the supplied OpenID
+  identifier. Only create a (new) username if the lookup fails. Thus
+  returning users will no longer get a new username if the data returned
+  by their OpenID provider changes. (Fixes `#14`_.)
+  Note that previous releases would create a new username with the same
+  OpenID identifier in this case. If that has happened in your
+  installation, there will be multiple usernames with the same OpenID
+  identifier. In that case the user will now always be logged into the
+  username that was last used, and a warning will be logged ("Multiple
+  users share the same openid identifier"). You should probably clean up
+  these "duplicate" usernames (usually by joining them).
+
+.. _#14: https://github.com/dairiki/authopenid-plugin/issues/14
+
+
 Version 0.4.6 (2013-06-27)
 ==========================
 

--- a/authopenid/authopenid.py
+++ b/authopenid/authopenid.py
@@ -147,8 +147,8 @@ class AuthOpenIdPlugin(Component):
             Enabling this option makes the retrieved authname from the
             OpenID provider authorative, i.e. it trusts the authname
             to be the unique username of the user. Enabling this disables
-            the collission checking, so two different OpenID urls may
-            suddenly get the same username if they have the same authname""")
+            the collision checking, so it may be possible to take over
+            an existing username or permission group.""")
 
     pape_method = Option('openid', 'pape_method', None,
             """Default PAPE method to request from OpenID provider.""")


### PR DESCRIPTION
Lookup username by OpenID identifier, instead of creating the name every time. Fixes issue 14.
