### PR TITLE
Fix error message if users cancels verification.

### DIFF
--- a/authopenid/authopenid.py
+++ b/authopenid/authopenid.py
@@ -534,7 +534,8 @@ class AuthOpenIdPlugin(Component):
         # us.  Status is a code indicating the response type. info is
         # either None or a string containing more information about
         # the return type.
-        info = oidconsumer.complete(req.args,req.args['openid.return_to'])
+        current_url = req.abs_href(req.path_info)
+        info = oidconsumer.complete(req.args,current_url)
 
         css_class = 'error'
         if info.status == consumer.FAILURE and info.identity_url:


### PR DESCRIPTION
Pass current URL to oidconsumer.complete. Fixes error message if users cancels verification.
